### PR TITLE
Add Shopify collections discovery and dropdown

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,14 +10,27 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 
 export default function Header({ 
-  collectionUrl, 
-  setCollectionUrl, 
+  storeInput, 
+  onStoreInputChange, 
+  onStorePaste,
   onLoad, 
   loading,
   urlHistory,
-  onSelectHistory 
+  onSelectHistory,
+  collections,
+  collectionsStatus,
+  collectionsError,
+  selectedHandle,
+  onSelectHandle,
 }) {
   const handleKeyPress = (e) => {
     if (e.key === 'Enter' && !loading) {
@@ -41,13 +54,55 @@ export default function Header({
           <div className="flex-1 flex items-center gap-2">
             <Input
               type="text"
-              placeholder="Paste Shopify collection URL (e.g., https://store.myshopify.com/collections/all)"
-              value={collectionUrl}
-              onChange={(e) => setCollectionUrl(e.target.value)}
+              placeholder="Paste Shopify store or collection URL"
+              value={storeInput}
+              onChange={(e) => onStoreInputChange(e.target.value)}
+              onPaste={(e) => {
+                const text = e.clipboardData.getData("text");
+                e.preventDefault();
+                onStorePaste(text);
+              }}
               onKeyPress={handleKeyPress}
               disabled={loading}
               className="flex-1 min-w-16rem"
             />
+            <Select
+              value={selectedHandle || undefined}
+              onValueChange={onSelectHandle}
+              disabled={loading || !storeInput}
+            >
+              <SelectTrigger className="min-w-[16rem]" aria-invalid={collectionsStatus === "error"}>
+                <SelectValue
+                  placeholder={
+                    collectionsStatus === "loading"
+                      ? "Discovering collections..."
+                      : collectionsStatus === "error"
+                      ? "Couldn't load collections"
+                      : collections?.length === 0
+                      ? "No collections found"
+                      : "Select a collection"
+                  }
+                />
+              </SelectTrigger>
+              <SelectContent align="start">
+                {collectionsStatus === "loading" && (
+                  <SelectItem value="__loading" disabled>
+                    Discovering collections...
+                  </SelectItem>
+                )}
+                {collectionsStatus === "error" && (
+                  <SelectItem value="__error" disabled>
+                    {collectionsError || "Couldn't load collections for this store"}
+                  </SelectItem>
+                )}
+                {collectionsStatus === "ready" &&
+                  collections.map((collection) => (
+                    <SelectItem key={collection.handle} value={collection.handle}>
+                      {collection.title} ({collection.products_count})
+                    </SelectItem>
+                  ))}
+              </SelectContent>
+            </Select>
             
             {urlHistory.length > 0 && (
               <DropdownMenu>
@@ -74,7 +129,7 @@ export default function Header({
 
             <Button 
               onClick={onLoad} 
-              disabled={loading || !collectionUrl.trim()}
+              disabled={loading || !storeInput.trim()}
               // variant="default"
             >
               {loading ? (

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -32,6 +32,15 @@ export default function Header({
   selectedHandle,
   onSelectHandle,
 }) {
+  const getHostFromValue = (value) => {
+    try {
+      const parsed = value.startsWith("http") ? new URL(value) : new URL(`https://${value}`);
+      return parsed.host;
+    } catch {
+      return value;
+    }
+  };
+
   const handleKeyPress = (e) => {
     if (e.key === 'Enter' && !loading) {
       onLoad();
@@ -112,7 +121,7 @@ export default function Header({
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-80">
-                  <DropdownMenuLabel>Recent Collections</DropdownMenuLabel>
+                  <DropdownMenuLabel>Recent Stores</DropdownMenuLabel>
                   <DropdownMenuSeparator />
                   {urlHistory.map((url, index) => (
                     <DropdownMenuItem 
@@ -120,7 +129,7 @@ export default function Header({
                       onClick={() => onSelectHistory(url)}
                       className="cursor-pointer"
                     >
-                      <div className="truncate text-sm">{url}</div>
+                      <div className="truncate text-sm">{getHostFromValue(url)}</div>
                     </DropdownMenuItem>
                   ))}
                 </DropdownMenuContent>

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -91,6 +91,7 @@ export async function discoverCollections(origin) {
     }
   }
 
+  const priorityHandles = ["all", "all-1", "all-products"];
   const filtered = allCollections
     .filter((c) => c.products_count > 0)
     .map((c) => ({
@@ -98,7 +99,18 @@ export async function discoverCollections(origin) {
       title: c.title,
       products_count: c.products_count,
     }))
-    .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" }));
+    .sort((a, b) => {
+      const aIndex = priorityHandles.indexOf(a.handle);
+      const bIndex = priorityHandles.indexOf(b.handle);
+
+      if (aIndex !== -1 && bIndex !== -1) {
+        return aIndex - bIndex;
+      }
+      if (aIndex !== -1) return -1;
+      if (bIndex !== -1) return 1;
+
+      return a.title.localeCompare(b.title, undefined, { sensitivity: "base" });
+    });
 
   saveCollectionsCache(origin, filtered);
   return filtered;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,0 +1,105 @@
+export function parseUserInputToURL(input) {
+  try {
+    const value = input?.trim();
+    if (!value) return null;
+    const prefixed = value.startsWith("http") ? value : `https://${value}`;
+    return new URL(prefixed);
+  } catch {
+    return null;
+  }
+}
+
+export function getOrigin(url) {
+  return url.origin;
+}
+
+export function getDisplayHost(url) {
+  return url.host;
+}
+
+export function extractCollectionHandle(url) {
+  const match = url.pathname.match(/^\/collections\/([^/]+)/);
+  return match ? match[1] : null;
+}
+
+const CACHE_PREFIX = "storelens:collections:";
+const TTL_MS = 21600000;
+
+export function loadCollectionsCache(origin) {
+  try {
+    const raw = localStorage.getItem(`${CACHE_PREFIX}${origin}`);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const { cachedAt, ttlMs, collections } = parsed;
+    if (!cachedAt || !ttlMs || !Array.isArray(collections)) return null;
+    if (Date.now() - cachedAt >= ttlMs) return null;
+    return collections;
+  } catch {
+    return null;
+  }
+}
+
+export function saveCollectionsCache(origin, collections) {
+  try {
+    const payload = {
+      cachedAt: Date.now(),
+      ttlMs: TTL_MS,
+      collections,
+    };
+    localStorage.setItem(`${CACHE_PREFIX}${origin}`, JSON.stringify(payload));
+  } catch {
+    /* noop */
+  }
+}
+
+async function fetchCollectionsPage(origin, page) {
+  const response = await fetch(
+    `${origin}/collections.json?limit=250&page=${page}`
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch collections");
+  }
+  const data = await response.json();
+  return Array.isArray(data?.collections) ? data.collections : [];
+}
+
+export async function discoverCollections(origin) {
+  const cached = loadCollectionsCache(origin);
+  if (cached) {
+    return cached;
+  }
+
+  const allCollections = [];
+  const seenPages = new Set();
+  const maxPages = 20;
+  let page = 1;
+  let keepGoing = true;
+
+  while (keepGoing && page <= maxPages) {
+    const collections = await fetchCollectionsPage(origin, page);
+    const signature = JSON.stringify(collections);
+    if (collections.length === 0 || seenPages.has(signature)) {
+      break;
+    }
+    seenPages.add(signature);
+    allCollections.push(...collections);
+    if (collections.length < 250) {
+      keepGoing = false;
+    } else {
+      page += 1;
+    }
+  }
+
+  const filtered = allCollections
+    .filter((c) => c.products_count > 0)
+    .map((c) => ({
+      handle: c.handle,
+      title: c.title,
+      products_count: c.products_count,
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" }));
+
+  saveCollectionsCache(origin, filtered);
+  return filtered;
+}

--- a/src/pages/StoreLens.jsx
+++ b/src/pages/StoreLens.jsx
@@ -32,6 +32,15 @@ export default function StoreLensApp() {
   const [inputHandle, setInputHandle] = useState("");
   const [discoverImmediately, setDiscoverImmediately] = useState(false);
   const discoverTimeoutRef = useRef(null);
+  const historyKey = "shopify-url-history";
+  const updateHistoryEntry = (entry) => {
+    if (!entry) return;
+    setUrlHistory((prev) => {
+      const updated = [entry, ...prev.filter((u) => u !== entry)].slice(0, 5);
+      localStorage.setItem(historyKey, JSON.stringify(updated));
+      return updated;
+    });
+  };
   
   // Filter states
   const [searchQuery, setSearchQuery] = useState("");
@@ -46,7 +55,7 @@ export default function StoreLensApp() {
 
   // Load URL history from localStorage
   useEffect(() => {
-    const saved = localStorage.getItem("shopify-url-history");
+    const saved = localStorage.getItem(historyKey);
     if (saved) {
       setUrlHistory(JSON.parse(saved));
     }
@@ -109,11 +118,14 @@ export default function StoreLensApp() {
         throw new Error("No products found in this collection");
       }
 
-      setProducts(allProducts);
-      setCurrentCollectionUrl(url);
-      resetFilters();
-      setError(null);
-    } catch (err) {
+    setProducts(allProducts);
+    setCurrentCollectionUrl(url);
+    resetFilters();
+    setError(null);
+    if (collectionsState.status !== "ready") {
+      updateHistoryEntry(url);
+    }
+  } catch (err) {
       setError(err.message);
     } finally {
       setLoading(false);
@@ -190,15 +202,6 @@ export default function StoreLensApp() {
   }, []);
 
   useEffect(() => {
-    if (!storeOrigin) return;
-    setUrlHistory((prev) => {
-      const updated = [storeOrigin, ...prev.filter((u) => u !== storeOrigin)].slice(0, 5);
-      localStorage.setItem("shopify-url-history", JSON.stringify(updated));
-      return updated;
-    });
-  }, [storeOrigin]);
-
-  useEffect(() => {
     if (discoverTimeoutRef.current) {
       clearTimeout(discoverTimeoutRef.current);
     }
@@ -227,6 +230,7 @@ export default function StoreLensApp() {
             collections,
             error: null,
           });
+          updateHistoryEntry(storeOrigin);
         }
       } catch (err) {
         if (!controller.signal.aborted) {

--- a/src/pages/StoreLens.jsx
+++ b/src/pages/StoreLens.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { Loader2, AlertCircle } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 
@@ -7,13 +7,31 @@ import Sidebar from "../components/Sidebar";
 import ProductGrid from "../components/ProductGrid";
 
 import { getDiscountData } from "@/lib/utils";
+import {
+  discoverCollections,
+  extractCollectionHandle,
+  getDisplayHost,
+  getOrigin,
+  parseUserInputToURL,
+} from "@/lib/store";
 
 export default function StoreLensApp() {
-  const [collectionUrl, setCollectionUrl] = useState("");
+  const [storeInput, setStoreInput] = useState("");
+  const [storeOrigin, setStoreOrigin] = useState("");
   const [products, setProducts] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [urlHistory, setUrlHistory] = useState([]);
+  const [collectionsState, setCollectionsState] = useState({
+    status: "idle",
+    collections: [],
+    error: null,
+  });
+  const [selectedHandle, setSelectedHandle] = useState("");
+  const [currentCollectionUrl, setCurrentCollectionUrl] = useState("");
+  const [inputHandle, setInputHandle] = useState("");
+  const [discoverImmediately, setDiscoverImmediately] = useState(false);
+  const discoverTimeoutRef = useRef(null);
   
   // Filter states
   const [searchQuery, setSearchQuery] = useState("");
@@ -34,58 +52,15 @@ export default function StoreLensApp() {
     }
   }, []);
 
-  // Check if URL is a bare domain (no collection path)
-  const isBareDomain = (url) => {
-    try {
-      const urlObj = new URL(url.startsWith('http') ? url : `https://${url}`);
-      const pathname = urlObj.pathname;
-      return !pathname || pathname === '/' || pathname === '';
-    } catch {
-      return false;
-    }
-  };
-
-  // Convert to bare hostname (for product links)
   const getHostname = (url) => {
     try {
-      const urlObj = new URL(url.startsWith('http') ? url : `https://${url}`);
+      const urlObj = new URL(url.startsWith("http") ? url : `https://${url}`);
       return urlObj.hostname;
     } catch {
       return false;
     }
   };
 
-  // Resolve default collection for a bare domain
-  const resolveDefaultCollection = async (baseUrl) => {
-    const urlObj = new URL(baseUrl.startsWith('http') ? baseUrl : `https://${baseUrl}`);
-    const domain = `${urlObj.protocol}//${urlObj.host}`;
-    
-    const candidates = [
-      'all',
-      'all-1', 
-      'all-products',
-    ];
-
-    for (const candidate of candidates) {
-      try {
-        const testUrl = `${domain}/collections/${candidate}/products.json?limit=1`;
-        const response = await fetch(testUrl);
-        
-        if (response.ok) {
-          const data = await response.json();
-          if (data.products && data.products.length > 0) {
-            return `${domain}/collections/${candidate}`;
-          }
-        }
-      } catch (err) {
-        continue;
-      }
-    }
-
-    return null;
-  };
-
-  // Convert Shopify collection URL to JSON endpoint
   const getJsonUrl = (url) => {
     try {
       const urlObj = new URL(url);
@@ -104,25 +79,13 @@ export default function StoreLensApp() {
     }
   };
 
-  // Fetch all products with pagination
   const fetchCollection = async (url) => {
     setLoading(true);
     setError(null);
     setProducts([]);
     
     try {
-      let resolvedUrl = url;
-      
-      // If it's a bare domain, try to resolve to default collection
-      if (isBareDomain(url)) {
-        const defaultCollection = await resolveDefaultCollection(url);
-        if (!defaultCollection) {
-          throw new Error("I couldn't find a collection of products to load. Please paste the full collection URL and try again.");
-        }
-        resolvedUrl = defaultCollection;
-      }
-      
-      const jsonUrl = getJsonUrl(resolvedUrl);
+      const jsonUrl = getJsonUrl(url);
       let allProducts = [];
       let page = 1;
       let hasMore = true;
@@ -147,15 +110,12 @@ export default function StoreLensApp() {
       }
 
       setProducts(allProducts);
-      
-      // Update URL history with the original input
+      setCurrentCollectionUrl(url);
       const newHistory = [url, ...urlHistory.filter(u => u !== url)].slice(0, 5);
       setUrlHistory(newHistory);
       localStorage.setItem("shopify-url-history", JSON.stringify(newHistory));
-      
-      // Reset filters
       resetFilters();
-      
+      setError(null);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -163,9 +123,53 @@ export default function StoreLensApp() {
     }
   };
 
+  const loadCollectionByHandle = async (handle, origin = storeOrigin) => {
+    if (!handle || !origin) {
+      setError("Please select a collection to load.");
+      return;
+    }
+    const url = `${origin}/collections/${handle}`;
+    setSelectedHandle(handle);
+    setInputHandle(handle);
+    await fetchCollection(url);
+  };
+
+  const applyUserInput = (value, { immediate = false, autoLoad = false } = {}) => {
+    const parsed = parseUserInputToURL(value);
+    if (!parsed) {
+      setStoreInput(value);
+      setStoreOrigin("");
+      setInputHandle("");
+      setSelectedHandle("");
+      return;
+    }
+    const origin = getOrigin(parsed);
+    const host = getDisplayHost(parsed);
+    const handle = extractCollectionHandle(parsed);
+    setStoreInput(host);
+    setStoreOrigin(origin);
+    setInputHandle(handle || "");
+    if (handle) {
+      setSelectedHandle(handle);
+      if (autoLoad) {
+        loadCollectionByHandle(handle, origin);
+      } else {
+        setCurrentCollectionUrl(`${origin}/collections/${handle}`);
+      }
+    } else {
+      setSelectedHandle("");
+      setCurrentCollectionUrl("");
+    }
+    setDiscoverImmediately(immediate);
+  };
+
   const handleLoadCollection = () => {
-    if (collectionUrl.trim()) {
-      fetchCollection(collectionUrl.trim());
+    if (inputHandle) {
+      loadCollectionByHandle(inputHandle, storeOrigin);
+    } else if (selectedHandle) {
+      loadCollectionByHandle(selectedHandle, storeOrigin);
+    } else {
+      setError("Please select a collection to load.");
     }
   };
 
@@ -178,6 +182,93 @@ export default function StoreLensApp() {
     setSelectedOptions({});
     setInStockOnly(true);
     setSaleOnly(false);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (discoverTimeoutRef.current) {
+        clearTimeout(discoverTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (discoverTimeoutRef.current) {
+      clearTimeout(discoverTimeoutRef.current);
+    }
+    if (!storeOrigin) {
+      setCollectionsState({
+        status: "idle",
+        collections: [],
+        error: null,
+      });
+      return;
+    }
+
+    const delay = discoverImmediately ? 0 : 400;
+    const controller = new AbortController();
+    discoverTimeoutRef.current = setTimeout(async () => {
+      setCollectionsState((prev) => ({
+        ...prev,
+        status: "loading",
+        error: null,
+      }));
+      try {
+        const collections = await discoverCollections(storeOrigin);
+        if (!controller.signal.aborted) {
+          setCollectionsState({
+            status: "ready",
+            collections,
+            error: null,
+          });
+        }
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setCollectionsState({
+            status: "error",
+            collections: [],
+            error: err.message || "Couldn't load collections for this store",
+          });
+        }
+      } finally {
+        setDiscoverImmediately(false);
+      }
+    }, delay);
+
+    return () => {
+      controller.abort();
+      if (discoverTimeoutRef.current) {
+        clearTimeout(discoverTimeoutRef.current);
+      }
+    };
+  }, [storeOrigin, discoverImmediately]);
+
+  useEffect(() => {
+    if (collectionsState.status !== "ready") return;
+    if (inputHandle && collectionsState.collections.some((c) => c.handle === inputHandle)) {
+      setSelectedHandle(inputHandle);
+    }
+  }, [collectionsState, inputHandle]);
+
+  const handleInputChange = (value) => {
+    setError(null);
+    applyUserInput(value);
+  };
+
+  const handlePaste = (value) => {
+    setError(null);
+    applyUserInput(value, { immediate: true, autoLoad: true });
+  };
+
+  const handleSelectHistory = (url) => {
+    applyUserInput(url, { immediate: true, autoLoad: true });
+  };
+
+  const handleSelectHandle = (handle) => {
+    setError(null);
+    setSelectedHandle(handle);
+    setInputHandle(handle);
+    loadCollectionByHandle(handle, storeOrigin);
   };
 
   // Extract unique filter values
@@ -338,15 +429,18 @@ export default function StoreLensApp() {
   return (
     <div className="min-h-screen bg-secondary">
       <Header
-        collectionUrl={collectionUrl}
-        setCollectionUrl={setCollectionUrl}
+        storeInput={storeInput}
+        onStoreInputChange={handleInputChange}
+        onStorePaste={handlePaste}
         onLoad={handleLoadCollection}
         loading={loading}
         urlHistory={urlHistory}
-        onSelectHistory={(url) => {
-          setCollectionUrl(url);
-          fetchCollection(url);
-        }}
+        onSelectHistory={handleSelectHistory}
+        collections={collectionsState.collections}
+        collectionsStatus={collectionsState.status}
+        collectionsError={collectionsState.error}
+        selectedHandle={selectedHandle}
+        onSelectHandle={handleSelectHandle}
       />
 
       <div className="flex">
@@ -390,19 +484,17 @@ export default function StoreLensApp() {
           {!loading && !error && products.length === 0 && (
             <div className="text-center py-20">
               <p className="text-muted-foreground text-lg">
-                Enter a Shopify collection URL above to get started
+                Enter a Shopify store or collection URL above to get started
               </p>
             </div>
           )}
-          {/* <h2 className="text-center text-white text-lg">{new URL(collectionUrl).hostname}</h2> */}
-
           {!loading && products.length > 0 && (
             <ProductGrid
               products={filteredProducts}
               totalProducts={products.length}
               sortBy={sortBy}
               setSortBy={setSortBy}
-              collectionUrl={getHostname(collectionUrl)}
+              collectionUrl={getHostname(currentCollectionUrl)}
             />
           )}
         </main>

--- a/src/pages/StoreLens.jsx
+++ b/src/pages/StoreLens.jsx
@@ -111,9 +111,6 @@ export default function StoreLensApp() {
 
       setProducts(allProducts);
       setCurrentCollectionUrl(url);
-      const newHistory = [url, ...urlHistory.filter(u => u !== url)].slice(0, 5);
-      setUrlHistory(newHistory);
-      localStorage.setItem("shopify-url-history", JSON.stringify(newHistory));
       resetFilters();
       setError(null);
     } catch (err) {
@@ -191,6 +188,15 @@ export default function StoreLensApp() {
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (!storeOrigin) return;
+    setUrlHistory((prev) => {
+      const updated = [storeOrigin, ...prev.filter((u) => u !== storeOrigin)].slice(0, 5);
+      localStorage.setItem("shopify-url-history", JSON.stringify(updated));
+      return updated;
+    });
+  }, [storeOrigin]);
 
   useEffect(() => {
     if (discoverTimeoutRef.current) {


### PR DESCRIPTION
## Summary
- add URL parsing, collection discovery, and 6-hour localStorage caching with defensive pagination
- update StoreLens flow to normalize store input, discover collections, and load selections without defaulting to all
- add collections dropdown UI with loading/error states and handle auto-selection for pasted collection URLs

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942882dbd9c832ab47653e3a6f6c396)